### PR TITLE
OnPayloadSigned expects full json response instead the signature

### DIFF
--- a/Assets/Plugins/Android/Source/dapp/DAppViewModel.kt
+++ b/Assets/Plugins/Android/Source/dapp/DAppViewModel.kt
@@ -247,7 +247,7 @@ class DAppViewModel
         when(response)
         {
             is OperationTezosResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnContractCallCompleted", response.toJson().toString())
-            is SignPayloadTezosResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnPayloadSigned", response.signature.toString())
+            is SignPayloadTezosResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnPayloadSigned", response.toJson().toString())
             is BroadcastTezosResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnBroadcastResponse", response.toString())
             is PermissionBeaconResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnAccountConnected", response.toJson().toString())
             //is BlockchainBeaconResponse -> UnityPlayer.UnitySendMessage("UnityBeacon", "OnHandshakeReceived", response.destination.id)


### PR DESCRIPTION
It was reported by some users that RequestSignPayload doesn't work on Android. Upon further analysis, it looked that on android, the payload sent to MessageReceiver.PayloadSigned was only the signature, which caused JsonSerializer.Deserialize to fail. On other platforms like WebGL, the payload isthe full JSON response.

The line changed in this commit was indeed sending only the signature instead of the full Json object that is expected.