### PR TITLE
Fix ios open wallet

### DIFF
--- a/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
+++ b/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
@@ -79,13 +79,13 @@ namespace TezosSDK.Tezos.Wallet
             var address = _beaconConnector.GetActiveAccountAddress();
             if (!string.IsNullOrEmpty(address))
             {
-                Debug.Log($"Active address: {address}");
+                // Active address, let's disconnect it
                 _beaconConnector.DisconnectAccount();
                 yield return new WaitForSeconds(2.5f);
             }
             if (string.IsNullOrEmpty(_handshake))
             {
-                Debug.Log("No handshake, Waiting for handshake...");
+                //No handshake, Waiting for handshake...
                 yield return new WaitForSeconds(2.5f);
             }
 

--- a/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
+++ b/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Text.Json;
 using Beacon.Sdk.Beacon.Sign;
 using TezosSDK.Beacon;
@@ -71,18 +72,44 @@ namespace TezosSDK.Tezos.Wallet
             };
         }
 
+        // Below there are some async/wait workarounds and magic numbers, 
+        // we should rewrite the Beacon connector to be coroutine compatible.
+        private IEnumerator OnOpenWallet(bool withRedirectToWallet)
+        {
+            var address = _beaconConnector.GetActiveAccountAddress();
+            if (!string.IsNullOrEmpty(address))
+            {
+                Debug.Log($"Active address: {address}");
+                _beaconConnector.DisconnectAccount();
+                yield return new WaitForSeconds(2.5f);
+            }
+            if (string.IsNullOrEmpty(_handshake))
+            {
+                Debug.Log("No handshake, Waiting for handshake...");
+                yield return new WaitForSeconds(2.5f);
+            }
+
+#if UNITY_ANDROID || UNITY_IOS
+            if (withRedirectToWallet){
+                _beaconConnector.RequestTezosPermission(
+                    networkName: TezosConfig.Instance.Network.ToString(),
+                    networkRPC: TezosConfig.Instance.RpcBaseUrl);
+                yield return new WaitForSeconds(2.5f);
+                if (!string.IsNullOrEmpty(_handshake)){
+                    Application.OpenURL($"tezos://?type=tzip10&data={_handshake}");
+                }
+            }
+#endif
+        }
+
         public void Connect(WalletProviderType walletProvider, bool withRedirectToWallet)
         {
             _beaconConnector.InitWalletProvider(
                 network: TezosConfig.Instance.Network.ToString(),
                 rpc: TezosConfig.Instance.RpcBaseUrl,
                 walletProviderType: walletProvider);
-
             _beaconConnector.ConnectAccount();
-#if UNITY_ANDROID || UNITY_IOS
-            if (withRedirectToWallet)
-                Application.OpenURL($"tezos://?type=tzip10&data={_handshake}");
-#endif
+            CoroutineRunner.Instance.StartWrappedCoroutine(OnOpenWallet(withRedirectToWallet));
         }
 
         public void Disconnect()


### PR DESCRIPTION
This PR tries to resolve #14.

We are getting a problem related to async/wait when connecting to the wallet. 
We open the wallet before connecting with Beacon, or before get the handshake, or before set the Beacon peers.

Before that PR the only way to login with a wallet on iOS it was very tricky. You need to login, open the wallet, get stuck on the wallet screen, back to the game manually, back to the wallet again, accept and back to the game. And usually does not work.

On `BeaconConnectorDotNet` we have a lot of async methods that are not called right, I believe that we should rewrite this to make more sense to a Unity project.

I tried to rewrite `BeaconConnectorDotNet` with `Run.Task` but didn't work. I got many null exceptions with it. But, I would like to test it again in the future.

So, I propose to put some sleep calls after connecting to the wallet and before opening the wallet app. To make sure that we are ready to connect.