### PR TITLE
change marigold as default rpc nodes

### DIFF
--- a/Runtime/Scripts/Tezos/TezosConfig.cs
+++ b/Runtime/Scripts/Tezos/TezosConfig.cs
@@ -11,7 +11,7 @@ namespace TezosSDK.Tezos
 
         public NetworkType Network { get; set; } = NetworkType.ghostnet;
 
-        public string RpcBaseUrl => $"https://rpc.{Network}.teztnets.xyz";
+        public string RpcBaseUrl => $"https://{Network}.tezos.marigold.dev";
         public int DefaultTimeoutSeconds => 45;
     }
 


### PR DESCRIPTION
https://rpc.ghostnet.teztnets.xyz/version is very unstable for me. Returning a lot of 503.


We should make it customizable too