### PR TITLE
Fix typo in Transfer scene

### DIFF
--- a/Examples/Transfer.meta
+++ b/Examples/Transfer.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 092a2a65c68578342ad3ddf800b18be0
+guid: 05512a42de55c4709b08c5c05baf5ba0
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Examples/Transfer/_TransferToken.unity
+++ b/Examples/Transfer/_TransferToken.unity
@@ -1373,7 +1373,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Destination Address:'
+  m_text: 'Transfer Amount:'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}


### PR DESCRIPTION
The transfer example scene has two files labeled "Destination Address." The second one should be something like "Transfer Amount."

Before:

<img width="358" alt="Screenshot 2023-12-14 at 12 17 16 PM" src="https://github.com/trilitech/tezos-unity-sdk/assets/6494785/64b6287e-aa56-45eb-9333-0c09d415fdc2">

After:
<img width="487" alt="Screenshot 2023-12-14 at 12 14 13 PM" src="https://github.com/trilitech/tezos-unity-sdk/assets/6494785/ea35f3b1-34ff-45da-9e66-86ef78dec3e8">
