### PR TITLE
Make InitWalletProvider callable up front, allowing initialization in a splash loading scene

### DIFF
--- a/Runtime/Scripts/Tezos/Wallet/IWalletProvider.cs
+++ b/Runtime/Scripts/Tezos/Wallet/IWalletProvider.cs
@@ -16,6 +16,11 @@ namespace TezosSDK.Tezos.Wallet
         void OnReady();
 
         /// <summary>
+        /// Initializes the WalletProvider
+        /// </summary>
+	void InitWalletProvider(WalletProviderType walletProvider);
+
+        /// <summary>
         /// Makes a call to connect with a wallet
         /// <param name="withRedirectToWallet">Should we open wallet app on mobiles after connect?</param>
         /// </summary>

--- a/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
+++ b/Runtime/Scripts/Tezos/Wallet/WalletProvider.cs
@@ -19,6 +19,8 @@ namespace TezosSDK.Tezos.Wallet
         private string _signature;
         private string _transactionHash;
 
+        private bool _isWalletProviderInitialized = false;
+
         public WalletProvider(DAppMetadata dAppMetadata)
         {
             _dAppMetadata = dAppMetadata;
@@ -102,13 +104,26 @@ namespace TezosSDK.Tezos.Wallet
             _beaconConnector.OnReady();
         }
 
-        public void Connect(WalletProviderType walletProvider, bool withRedirectToWallet)
+        public void InitWalletProvider(WalletProviderType walletProvider)
         {
+            if (_isWalletProviderInitialized)
+            {
+                return;
+            }
+
             _beaconConnector.InitWalletProvider(
                 network: TezosConfig.Instance.Network.ToString(),
                 rpc: TezosConfig.Instance.RpcBaseUrl,
                 walletProviderType: walletProvider,
                 dAppMetadata: _dAppMetadata);
+        }
+        
+        public void Connect(WalletProviderType walletProvider, bool withRedirectToWallet)
+        {
+            if (!_isWalletProviderInitialized)
+            {
+                InitWalletProvider(walletProvider);
+            }
 
             _beaconConnector.ConnectAccount();
             CoroutineRunner.Instance.StartWrappedCoroutine(OnOpenWallet(withRedirectToWallet));


### PR DESCRIPTION
There are some situations where you might want to initialize the SDK in a different scene than where you want to connect the wallet.

An example: Custom Splash/Loading- Screen that does some initialization, perhaps connecting to a backend server.

In the case of WebGL Builds, this wouldn't work, as the Walletprovider is only initialized on Connecting the Wallet, thereby throwing an error on startup.

This PR isolates the initialization code into a public method, and tracks it in  a private variable. The Connect code is refactured to use the same method, maintaining backward compatability but extending functionality.