### PR TITLE
Change TMP dependency to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.unity.textmeshpro": "3.2.0-pre.7"
+    "com.unity.textmeshpro": "3.0.6"
   },
   "keywords": [
     "tezos",


### PR DESCRIPTION
Change TMP dependency to 3.0.6 as 3.2 can throw exceptions in some Unity versions