### PR TITLE
Fix for missing dependency?

### DIFF
--- a/Editor/Scripts/IssueReportFormWindow.cs
+++ b/Editor/Scripts/IssueReportFormWindow.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using Unity.Plastic.Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;

--- a/Runtime/Scripts/Beacon/Connectors/BeaconConnectorFactory.cs
+++ b/Runtime/Scripts/Beacon/Connectors/BeaconConnectorFactory.cs
@@ -18,6 +18,7 @@ namespace TezosSDK.Beacon
 				case RuntimePlatform.WindowsPlayer:
 				case RuntimePlatform.WindowsEditor:
 				case RuntimePlatform.LinuxPlayer:
+                                case RuntimePlatform.LinuxEditor:
 				case RuntimePlatform.OSXPlayer:
 				case RuntimePlatform.OSXEditor:
 					return new BeaconConnectorDotNet(eventManager);


### PR DESCRIPTION
Should be:

using Newtonsoft.Json.Linq;

instead of

using Unity.Plastic.Newtonsoft.Json.Linq;